### PR TITLE
[PKG-4249] 1.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 # Please do not modify
 
 # Ignore all files and folders in root
-*
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channel:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-upload_channel:
+upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,6 @@ requirements:
   run:
     - python
     - opentelemetry-proto =={{ version }}
-  # NOTE backoff only required for py<37 but pip checks fails without it
-    - backoff >=1.10.0,<3.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp-proto-common" %}
-{% set version = "1.24.0" %}
+{% set version = "1.23.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_common-{{ version }}.tar.gz
-  sha256: 5d31fa1ff976cacc38be1ec4e3279a3f88435c75b38b1f7a099a1faffc302461
+  sha256: 35e4ea909e7a0b24235bd0aaf17fba49676527feb1823b46565ff246d5a1ab18
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,9 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   home: https://opentelemetry.io/
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common
+  doc_url: https://opentelemetry.io/docs/
+  description: This library is provided as a convenience to encode to Protobuf. 
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 35e4ea909e7a0b24235bd0aaf17fba49676527feb1823b46565ff246d5a1ab18
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - hatchling
     - pip
   run:
-    - python >=3.8
+    - python
     - opentelemetry-proto =={{ version }}
   # NOTE backoff only required for py<37 but pip checks fails without it
     - backoff >=1.10.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ about:
   summary: OpenTelemetry Protobuf encoding
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   home: https://opentelemetry.io/
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common
   doc_url: https://opentelemetry.io/docs/


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-common 1.23.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4249]
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common)
- [Upstream [changelog](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.23.0) / [diff](https://github.com/open-telemetry/opentelemetry-python/compare/v1.15.0...v1.23.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/opentelemetry-proto-feedstock/pull/2

### Explanation of changes:

- Dropped noarch.
- Updated about block
- Unable to run upstream tests as they require the opentelemetry.test module from the top level package and several missing dependencies.


[PKG-4249]: https://anaconda.atlassian.net/browse/PKG-4249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ