### PR TITLE
v1.30.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,3 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
-  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
-  - https://staging.continuum.io/prefect/fs/opentelemetry-sdk-feedstock/pr5/adb5888
-  - https://staging.continuum.io/prefect/fs/opentelemetry-proto-feedstock/pr6/85e2f29
-  
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
+  - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
+  - https://staging.continuum.io/prefect/fs/opentelemetry-sdk-feedstock/pr5/adb5888
+  
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,7 @@ channels:
   - https://staging.continuum.io/prefect/fs/opentelemetry-api-feedstock/pr5/e751223
   - https://staging.continuum.io/prefect/fs/opentelemetry-semantic-conventions-feedstock/pr6/c27cf44
   - https://staging.continuum.io/prefect/fs/opentelemetry-sdk-feedstock/pr5/adb5888
+  - https://staging.continuum.io/prefect/fs/opentelemetry-proto-feedstock/pr6/85e2f29
   
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp-proto-common" %}
-{% set version = "1.26.0" %}
+{% set version = "1.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_common-{{ version }}.tar.gz
-  sha256: bdbe50e2e22a1c71acaa0c8ba6efaadd58882e5a5978737a44a4c4b10d304c92
+  sha256: ddbfbf797e518411857d0ca062c957080279320d6235a279f7b64ced73c13897
   patches:
     - patches/0001-remove-opentelemetry-test-dependencies.patch
 
 build:
   skip: True        # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
     - patches/0001-remove-opentelemetry-test-dependencies.patch
 
 build:
-  skip: True        # [py<38]
+  skip: True  # [py<38]
+  skip: True  # [s390x]   
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/patches/0001-remove-opentelemetry-test-dependencies.patch
+++ b/recipe/patches/0001-remove-opentelemetry-test-dependencies.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] remove opentelemetry test dependencies
  1 file changed, 316 deletions(-)
 
 diff --git a/tests/test_metrics_encoder.py b/tests/test_metrics_encoder.py
-index 6d68b48..0dfac29 100644
+index 0f435ae..4f2dbf6 100644
 --- a/tests/test_metrics_encoder.py
 +++ b/tests/test_metrics_encoder.py
-@@ -47,7 +47,6 @@ from opentelemetry.sdk.resources import Resource
+@@ -52,7 +52,6 @@ from opentelemetry.sdk.resources import Resource
  from opentelemetry.sdk.util.instrumentation import (
      InstrumentationScope as SDKInstrumentationScope,
  )
@@ -19,7 +19,7 @@ index 6d68b48..0dfac29 100644
  
  
  class TestOTLPMetricsEncoder(unittest.TestCase):
-@@ -73,321 +72,6 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
+@@ -97,321 +96,8 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
          ),
      )
  
@@ -337,10 +337,44 @@ index 6d68b48..0dfac29 100644
 -        )
 -        actual = encode_metrics(metrics_data)
 -        self.assertEqual(expected, actual)
--
+ 
++   
      def test_encode_histogram(self):
          metrics_data = MetricsData(
              resource_metrics=[
--- 
-2.45.2
-
+@@ -973,35 +659,3 @@ class TestOTLPMetricsEncoder(unittest.TestCase):
+         # pylint: disable=protected-access
+         actual = encode_metrics(metrics_data)
+         self.assertEqual(expected, actual)
+-
+-    def test_encoding_exception_reraise(self):
+-        # this number is too big to fit in a signed 64-bit proto field and causes a ValueError
+-        big_number = 2**63
+-        metrics_data = MetricsData(
+-            resource_metrics=[
+-                ResourceMetrics(
+-                    resource=Resource(
+-                        attributes={},
+-                        schema_url="resource_schema_url",
+-                    ),
+-                    scope_metrics=[
+-                        ScopeMetrics(
+-                            scope=SDKInstrumentationScope(
+-                                name="first_name",
+-                                version="first_version",
+-                                schema_url="insrumentation_scope_schema_url",
+-                            ),
+-                            metrics=[_generate_sum("sum_double", big_number)],
+-                            schema_url="instrumentation_scope_schema_url",
+-                        )
+-                    ],
+-                    schema_url="resource_schema_url",
+-                )
+-            ]
+-        )
+-        with self.assertRaises(EncodingException) as context:
+-            encode_metrics(metrics_data)
+-
+-        # assert that the EncodingException wraps the metric and original exception
+-        assert isinstance(context.exception.metric, Metric)
+-        assert isinstance(context.exception.original_exception, ValueError)


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-common v1.30.0

**Destination channel:**  defaults

### Links

- [PKG-7681](https://anaconda.atlassian.net/browse/PKG-7681) 
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/v1.30.0/exporter/opentelemetry-exporter-otlp-proto-common)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Update pinnings
- Update patch



[PKG-7681]: https://anaconda.atlassian.net/browse/PKG-7681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ