### PR TITLE
opentelemetry-exporter-otlp-proto-common 1.40.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp-proto-common" %}
-{% set version = "1.38.0" %}
+{% set version = "1.40.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: e333278afab4695aa8114eeb7bf4e44e65c6607d54968271a249c180b2cb605c
+  sha256: 1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa
 
 build:
   number: 0
@@ -40,7 +40,7 @@ test:
     - pytest >=7.4.4
     - opentelemetry-api =={{ version }}
     - opentelemetry-sdk =={{ version }}
-    - opentelemetry-semantic-conventions ==0.59b0
+    - opentelemetry-semantic-conventions ==0.61b0
 
 about:
   home: https://opentelemetry.io


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-common 1.40.0

**Destination channel:** defaults

### Links

- [PKG-14556](https://anaconda.atlassian.net/browse/PKG-14556)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074)
- Related: prior epic [PKG-10837](https://anaconda.atlassian.net/browse/PKG-10837) (1.38.0/0.59b0, Done)
- Blocks: [PKG-14486](https://anaconda.atlassian.net/browse/PKG-14486) (pydantic-ai)
- [PyPI release](https://pypi.org/project/opentelemetry-exporter-otlp-proto-common/1.40.0/)

### Explanation of changes:

- Bump opentelemetry-exporter-otlp-proto-common 1.38.0 -> 1.40.0.
- Tier 4 of the OTel ecosystem lockstep update.
- **Run dep** (verified against [PyPI requires_dist](https://pypi.org/pypi/opentelemetry-exporter-otlp-proto-common/1.40.0/json)):
  - `opentelemetry-proto == 1.40.0` (auto-bump via `=={{ version }}`) ✓ on pkgs/main
- **Test deps:** bumped `opentelemetry-semantic-conventions ==0.59b0` -> `==0.61b0`; api/sdk auto-bump via `=={{ version }}`.
- **abs.yaml deleted:** had only the deprecated `ANACONDA_ROCKET_ENABLE_PY314` flag. Sequential-via-defaults pattern (Tiers 1–3 all on pkgs/main).

[PKG-14556]: https://anaconda.atlassian.net/browse/PKG-14556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-10837]: https://anaconda.atlassian.net/browse/PKG-10837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14486]: https://anaconda.atlassian.net/browse/PKG-14486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ